### PR TITLE
큐(대기열) 토큰 검증 인터셉터 구현

### DIFF
--- a/src/main/java/io/project/concertbooking/common/annotation/TokenRequired.java
+++ b/src/main/java/io/project/concertbooking/common/annotation/TokenRequired.java
@@ -1,0 +1,11 @@
+package io.project.concertbooking.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TokenRequired {
+}

--- a/src/main/java/io/project/concertbooking/common/config/SwaggerConfig.java
+++ b/src/main/java/io/project/concertbooking/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package io.project.concertbooking.config;
+package io.project.concertbooking.common.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/io/project/concertbooking/common/config/WebConfig.java
+++ b/src/main/java/io/project/concertbooking/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package io.project.concertbooking.common.config;
+
+import io.project.concertbooking.interfaces.api.interceptor.QueueInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final QueueInterceptor queueInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(queueInterceptor);
+    }
+}

--- a/src/main/java/io/project/concertbooking/common/exception/ErrorCode.java
+++ b/src/main/java/io/project/concertbooking/common/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     SCHEDULE_NOT_FOUND(NOT_FOUND, "콘서트 스케줄을 찾을 수 없습니다."),
     RESERVATION_NOT_FOUND(NOT_FOUND, "좌석 예약을 찾을 수 없습니다."),
     SEAT_NOT_FOUND(NOT_FOUND, "좌석 정보를 찾을 수 없습니다."),
-    TOKEN_NOT_FOUND(NOT_FOUND, "발급되지 않은 대기열 토큰입니다.");
+    TOKEN_NOT_FOUND(NOT_FOUND, "발급되지 않은 대기열 토큰입니다."),
+    TOKEN_NOT_ACTIVE(NOT_FOUND, "활성화 상태가 아닌 토큰입니다.");
 
     /* 409 CONFLICT : Resource의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
 

--- a/src/main/java/io/project/concertbooking/domain/queue/Queue.java
+++ b/src/main/java/io/project/concertbooking/domain/queue/Queue.java
@@ -66,6 +66,14 @@ public class Queue {
                 .build();
     }
 
+    public boolean isExpired() {
+        return this.status == QueueStatus.EXPIRED;
+    }
+
+    public boolean isWaiting() {
+        return this.status == QueueStatus.WAITING;
+    }
+
     public void expireQueueToken() {
         this.status = QueueStatus.EXPIRED;
     }

--- a/src/main/java/io/project/concertbooking/interfaces/api/interceptor/QueueInterceptor.java
+++ b/src/main/java/io/project/concertbooking/interfaces/api/interceptor/QueueInterceptor.java
@@ -1,0 +1,46 @@
+package io.project.concertbooking.interfaces.api.interceptor;
+
+import io.project.concertbooking.common.annotation.TokenRequired;
+import io.project.concertbooking.domain.queue.QueueService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static io.micrometer.common.util.StringUtils.isBlank;
+import static java.util.Objects.isNull;
+
+@Component
+@RequiredArgsConstructor
+public class QueueInterceptor implements HandlerInterceptor {
+
+    private final QueueService queueService;
+
+    @Value("${queue.request-header-key}")
+    private String queueTokenHeader;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+        TokenRequired tokenRequired = handlerMethod.getMethod().getAnnotation(TokenRequired.class);
+        if (isNull(tokenRequired)) {
+            return true;
+        }
+
+        String token = request.getHeader(queueTokenHeader);
+        if (isBlank(token)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, queueTokenHeader + " header is missing.");
+            return false;
+        }
+
+        queueService.validateToken(token);
+        request.setAttribute(queueTokenHeader, token);
+
+        return true;
+    }
+}

--- a/src/main/java/io/project/concertbooking/interfaces/api/v1/concert/ConcertController.java
+++ b/src/main/java/io/project/concertbooking/interfaces/api/v1/concert/ConcertController.java
@@ -1,5 +1,6 @@
 package io.project.concertbooking.interfaces.api.v1.concert;
 
+import io.project.concertbooking.common.annotation.TokenRequired;
 import io.project.concertbooking.interfaces.api.support.ApiResponse;
 import io.project.concertbooking.interfaces.api.v1.concert.request.ReserveSeatRequest;
 import io.project.concertbooking.interfaces.api.v1.concert.response.GetScheduleResponse;
@@ -24,6 +25,7 @@ public class ConcertController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     })
+    @TokenRequired
     @GetMapping("/{concertId}/schedules")
     public ApiResponse<?> getSchedule(
             @RequestHeader("Queue-Token") @Parameter(description = "대기열 토큰", example = "123e4567-e89b-12d3-a456-426614174000") String queueToken,
@@ -50,6 +52,7 @@ public class ConcertController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     })
+    @TokenRequired
     @GetMapping("/schedules/{concertScheduleId}/seats")
     public ApiResponse<?> getSeat(
             @RequestHeader("Queue-Token") @Parameter(description = "대기열 토큰", example = "123e4567-e89b-12d3-a456-426614174000") String queueToken,
@@ -78,6 +81,7 @@ public class ConcertController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "예약 성공")
     })
+    @TokenRequired
     @PostMapping("/schedules/{concertScheduleId}/reservation/seats/{seatId}")
     public ApiResponse<?> reserveSeat(
             @RequestHeader("Queue-Token") @Parameter(description = "대기열 토큰", example = "123e4567-e89b-12d3-a456-426614174000") String queueToken,

--- a/src/main/java/io/project/concertbooking/interfaces/api/v1/payment/PaymentController.java
+++ b/src/main/java/io/project/concertbooking/interfaces/api/v1/payment/PaymentController.java
@@ -1,5 +1,6 @@
 package io.project.concertbooking.interfaces.api.v1.payment;
 
+import io.project.concertbooking.common.annotation.TokenRequired;
 import io.project.concertbooking.interfaces.api.support.ApiResponse;
 import io.project.concertbooking.interfaces.api.v1.payment.request.PaySeatRequest;
 import io.project.concertbooking.interfaces.api.v1.payment.response.PaySeatResponse;
@@ -21,6 +22,7 @@ public class PaymentController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "결제 성공")
     })
+    @TokenRequired
     @PostMapping("/seat-reservations/{seatReservationId}")
     public ApiResponse<?> paySeat(
             @RequestHeader("Queue-Token") @Parameter(description = "대기열 토큰", example = "123e4567-e89b-12d3-a456-426614174000") String queueToken,

--- a/src/test/java/io/project/concertbooking/domain/queue/QueueServiceTest.java
+++ b/src/test/java/io/project/concertbooking/domain/queue/QueueServiceTest.java
@@ -11,11 +11,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,8 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class QueueServiceTest {
@@ -139,13 +139,12 @@ class QueueServiceTest {
                     .willReturn(Optional.of(queue));
 
             // when
-            Optional<Queue> queueOpt = queueRepository.findByToken(token);
+            Queue foundQueue = queueService.findByToken(token);
 
             // then
-            assertThat(queueOpt.isPresent()).isTrue();
-            assertThat(queueOpt.get()).usingRecursiveComparison().isEqualTo(queue);
+            assertThat(foundQueue).usingRecursiveComparison().isEqualTo(queue);
+            verify(queueRepository, times(1)).findByToken(eq(token));
         }
-
     }
 
     @DisplayName("입력된 큐(대기열) ID를 통해 대기 순번을 반환한다.")
@@ -161,6 +160,61 @@ class QueueServiceTest {
         // then
         assertThat(waitingCount).isNotNull();
         assertThat(waitingCount).isEqualTo(12);
+    }
+
+    @Nested
+    @DisplayName("validateToken() 테스트")
+    class ValidateTokenTest {
+
+        @DisplayName("존재하지 않는 토큰으로 큐(대기열)를 검증하면 예외가 발생한다.")
+        @Test
+        void validateTokenWithEmptyToken() {
+            // given
+            String token = "550e8400-e29b-41d4-a716-446655440000";
+
+            // when, then
+            assertThatThrownBy(() -> queueService.validateToken(token))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        @DisplayName("활성화 상태가 아닌 토큰의 대기열을 검증하면 예외가 발생한다.")
+        @ParameterizedTest
+        @EnumSource(value = QueueStatus.class, names = {"WAITING", "EXPIRED"})
+        void validateTokenWithNotActiveToken(QueueStatus status) {
+            // given
+            String token = "550e8400-e29b-41d4-a716-446655440000";
+            Queue queue = fixtureMonkey.giveMeBuilder(Queue.class)
+                    .set("token", Values.just(token))
+                    .set("status", status)
+                    .sample();
+            given(queueRepository.findByToken(any(String.class)))
+                    .willReturn(Optional.of(queue));
+
+            // when, then
+            assertThatThrownBy(() -> queueService.validateToken(token))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TOKEN_NOT_ACTIVE);
+        }
+
+        @DisplayName("활성화 상태의 토큰을 검증한다.")
+        @Test
+        void validateToken() {
+            // given
+            String token = "550e8400-e29b-41d4-a716-446655440000";
+            Queue queue = fixtureMonkey.giveMeBuilder(Queue.class)
+                    .set("token", Values.just(token))
+                    .set("status", QueueStatus.ACTIVATED)
+                    .sample();
+            given(queueRepository.findByToken(any(String.class)))
+                    .willReturn(Optional.of(queue));
+
+            // when
+            queueService.validateToken(token);
+
+            // then
+            verify(queueRepository, times(1)).findByToken(token);
+        }
     }
 
     @DisplayName("활성화 가능한 최대 큐 크기만큼 대기열이 활성화되어 있으면 큐 활성화 로직은 작동하지 않는다.")

--- a/src/test/java/io/project/concertbooking/domain/queue/QueueTest.java
+++ b/src/test/java/io/project/concertbooking/domain/queue/QueueTest.java
@@ -3,6 +3,7 @@ package io.project.concertbooking.domain.queue;
 import io.project.concertbooking.domain.queue.enums.QueueStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,5 +24,37 @@ class QueueTest {
 
         // then
         assertThat(queue.getStatus()).isEqualTo(QueueStatus.EXPIRED);
+    }
+
+    @DisplayName("큐(대기열)가 만료 상태인지 확인한다.")
+    @ParameterizedTest
+    @CsvSource({"WAITING,false", "ACTIVATED,false", "EXPIRED,true"})
+    void isExpired(QueueStatus status, boolean expected) {
+        // given
+        Queue queue = Queue.builder()
+                .status(status)
+                .build();
+
+        // when
+        boolean isExpired = queue.isExpired();
+
+        // then
+        assertThat(isExpired).isEqualTo(expected);
+    }
+
+    @DisplayName("큐(대기열)가 대기 상태인지 확인한다.")
+    @ParameterizedTest
+    @CsvSource({"WAITING,true", "ACTIVATED,false", "EXPIRED,false"})
+    void isWaiting(QueueStatus status, boolean expected) {
+        // given
+        Queue queue = Queue.builder()
+                .status(status)
+                .build();
+
+        // when
+        boolean isExpired = queue.isWaiting();
+
+        // then
+        assertThat(isExpired).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
### 변경 내용 요약
- 발급된 토큰이며, 큐의 상태가 활성화된 경우에만 검증을 통과하는 인터셉터 작성
- 단위 테스트

### 인터셉터 사용 이유
- #32  참조