### PR TITLE
[STEP-10] 동시성 이슈 통합 테스트

### DIFF
--- a/src/main/java/io/project/concertbooking/application/point/PointFacade.java
+++ b/src/main/java/io/project/concertbooking/application/point/PointFacade.java
@@ -21,7 +21,7 @@ public class PointFacade {
     @Transactional
     public PointResult chargePoint(Long userId, Integer point) {
         User user = userService.findById(userId);
-        return resultMapper.toPointResult(pointService.charge(user, point));
+        return resultMapper.toPointResult(pointService.chargeWithLock(user, point));
     }
 
     public PointResult getPoint(Long userId) {

--- a/src/main/java/io/project/concertbooking/application/reservation/ReservationFacade.java
+++ b/src/main/java/io/project/concertbooking/application/reservation/ReservationFacade.java
@@ -26,7 +26,7 @@ public class ReservationFacade {
     public List<ReservationResult> reserve(Long concertScheduleId, Long userId, List<Long> seatIds) {
         User user = userService.findById(userId);
         ConcertSchedule concertSchedule = concertService.findScheduleById(concertScheduleId);
-        List<Seat> seats = concertService.findSeats(seatIds);
+        List<Seat> seats = concertService.findSeatsWithLock(seatIds);
         List<Reservation> reservations = reservationService.createReservation(user, concertSchedule, seats);
         return reservations.stream()
                 .map(r -> ReservationResult.of(r, concertSchedule))

--- a/src/main/java/io/project/concertbooking/domain/concert/ConcertService.java
+++ b/src/main/java/io/project/concertbooking/domain/concert/ConcertService.java
@@ -46,4 +46,12 @@ public class ConcertService {
 
         return seats;
     }
+    public List<Seat> findSeatsWithLock(List<Long> seatIds) {
+        List<Seat> seats = concertRepository.findSeatsWithLock(seatIds);
+
+        if (seatIds.size() != seats.size())
+            throw new CustomException(ErrorCode.SEAT_NOT_FOUND);
+
+        return seats;
+    }
 }

--- a/src/main/java/io/project/concertbooking/domain/concert/IConcertRepository.java
+++ b/src/main/java/io/project/concertbooking/domain/concert/IConcertRepository.java
@@ -20,5 +20,7 @@ public interface IConcertRepository {
 
     List<Seat> findSeats(List<Long> seatIds);
 
+    List<Seat> findSeatsWithLock(List<Long> seatIds);
+
     Seat saveSeat(Seat seat);
 }

--- a/src/main/java/io/project/concertbooking/domain/point/IPointRepository.java
+++ b/src/main/java/io/project/concertbooking/domain/point/IPointRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 public interface IPointRepository {
     Optional<Point> findByUser(User user);
 
+    Optional<Point> findByUserWithLock(User user);
+
     Point savePoint(Point point);
 
     PointHistory saveHistory(PointHistory pointHistory);

--- a/src/main/java/io/project/concertbooking/domain/point/PointService.java
+++ b/src/main/java/io/project/concertbooking/domain/point/PointService.java
@@ -40,6 +40,23 @@ public class PointService {
     }
 
     @Transactional
+    public Point chargeWithLock(User user, Integer chargePoint) {
+        Optional<Point> pointOpt = pointRepository.findByUserWithLock(user);
+
+        Point point;
+
+        if (pointOpt.isPresent()) {
+            point = pointOpt.get();
+            point.charge(chargePoint);
+        } else {
+            point = Point.createPoint(user, chargePoint);
+        }
+        saveHistory(user, chargePoint, TransactionType.CHARGE);
+
+        return pointRepository.savePoint(point);
+    }
+
+    @Transactional
     public Point use(User user, Integer usePoint) {
         Point point = pointRepository.findByUser(user)
                 .orElseGet(() -> pointRepository.savePoint(Point.createPoint(user, 0)));

--- a/src/main/java/io/project/concertbooking/infrastructure/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/io/project/concertbooking/infrastructure/concert/repository/ConcertRepositoryImpl.java
@@ -54,6 +54,11 @@ public class ConcertRepositoryImpl implements IConcertRepository {
     }
 
     @Override
+    public List<Seat> findSeatsWithLock(List<Long> seatIds) {
+        return seatJpaRepository.findAllByIdWithPessimisticLock(seatIds);
+    }
+
+    @Override
     public Seat saveSeat(Seat seat) {
         return seatJpaRepository.save(seat);
     }

--- a/src/main/java/io/project/concertbooking/infrastructure/concert/repository/SeatJpaRepository.java
+++ b/src/main/java/io/project/concertbooking/infrastructure/concert/repository/SeatJpaRepository.java
@@ -3,11 +3,18 @@ package io.project.concertbooking.infrastructure.concert.repository;
 import io.project.concertbooking.domain.concert.ConcertSchedule;
 import io.project.concertbooking.domain.concert.Seat;
 import io.project.concertbooking.domain.concert.enums.SeatStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
     List<Seat> findAllByConcertSchedule(ConcertSchedule concertSchedule);
     List<Seat> findAllByStatus(SeatStatus status);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Seat s WHERE s.seatId IN :ids")
+    List<Seat> findAllByIdWithPessimisticLock(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/io/project/concertbooking/infrastructure/point/repository/PointJpaRepository.java
+++ b/src/main/java/io/project/concertbooking/infrastructure/point/repository/PointJpaRepository.java
@@ -2,10 +2,17 @@ package io.project.concertbooking.infrastructure.point.repository;
 
 import io.project.concertbooking.domain.point.Point;
 import io.project.concertbooking.domain.user.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PointJpaRepository extends JpaRepository<Point, Long> {
     Optional<Point> findByUser(User user);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Point p WHERE p.user = :user")
+    Optional<Point> findByUserWithPessimisticLock(@Param("user") User user);
 }

--- a/src/main/java/io/project/concertbooking/infrastructure/point/repository/PointRepositoryImpl.java
+++ b/src/main/java/io/project/concertbooking/infrastructure/point/repository/PointRepositoryImpl.java
@@ -22,6 +22,11 @@ public class PointRepositoryImpl implements IPointRepository {
     }
 
     @Override
+    public Optional<Point> findByUserWithLock(User user) {
+        return pointJpaRepository.findByUserWithPessimisticLock(user);
+    }
+
+    @Override
     public Point savePoint(Point point) {
         return pointJpaRepository.save(point);
     }

--- a/src/test/java/io/project/concertbooking/application/reservation/ReservationFacadeConcurrencyTest.java
+++ b/src/test/java/io/project/concertbooking/application/reservation/ReservationFacadeConcurrencyTest.java
@@ -1,0 +1,124 @@
+package io.project.concertbooking.application.reservation;
+
+import com.navercorp.fixturemonkey.customizer.Values;
+import io.project.concertbooking.common.exception.CustomException;
+import io.project.concertbooking.domain.concert.Concert;
+import io.project.concertbooking.domain.concert.ConcertSchedule;
+import io.project.concertbooking.domain.concert.Seat;
+import io.project.concertbooking.domain.concert.enums.SeatStatus;
+import io.project.concertbooking.domain.user.User;
+import io.project.concertbooking.infrastructure.concert.repository.ConcertJpaRepository;
+import io.project.concertbooking.infrastructure.concert.repository.ConcertScheduleJpaRepository;
+import io.project.concertbooking.infrastructure.concert.repository.SeatJpaRepository;
+import io.project.concertbooking.infrastructure.reservation.ReservationJpaRepository;
+import io.project.concertbooking.infrastructure.user.repository.UserJpaRepository;
+import io.project.concertbooking.support.IntegrationTestSupport;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.time.api.DateTimes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[ReservationFacade - 동시성 테스트]")
+public class ReservationFacadeConcurrencyTest extends IntegrationTestSupport {
+
+    @Autowired
+    ReservationFacade reservationFacade;
+
+    @Autowired
+    UserJpaRepository userJpaRepository;
+
+    @Autowired
+    ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    ConcertScheduleJpaRepository concertScheduleJpaRepository;
+
+    @Autowired
+    SeatJpaRepository seatJpaRepository;
+
+    @Autowired
+    ReservationJpaRepository reservationJpaRepository;
+
+    @Nested
+    @DisplayName("[createReservation() - 콘서트 좌석 예약 테스트]")
+    class CreateReservationTest {
+
+        @DisplayName("동시에 5개의 예약 요청이 들어오면, 하나만 성공하고 4개는 실패한다.")
+        @RepeatedTest(value = 5, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
+        void createReservation() throws Exception {
+            // given
+            User user = userJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(User.class)
+                            .sample()
+            );
+            LocalDateTime now = LocalDateTime.now();
+            Concert concert = concertJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Concert.class)
+                            .set("name", Arbitraries.strings().withCharRange('A', 'Z').ofLength(10).map(s -> s + " Concert"))
+                            .sample()
+            );
+            ConcertSchedule schedule = concertScheduleJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(ConcertSchedule.class)
+                            .set("concert", Values.just(concert))
+                            .set("scheduleDt", DateTimes.dateTimes().atTheEarliest(now.plusDays(7L))
+                                    .atTheLatest(now.plusDays(60L)))
+                            .sample()
+            );
+            Seat seat1 = seatJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Seat.class)
+                            .set("concertSchedule", Values.just(schedule))
+                            .set("number", 1)
+                            .set("price", Arbitraries.integers().greaterOrEqual(1).lessOrEqual(10).map(n -> n * 10000))
+                            .set("status", Values.just(SeatStatus.EMPTY))
+                            .sample()
+            );
+            Seat seat2 = seatJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Seat.class)
+                            .set("concertSchedule", Values.just(schedule))
+                            .set("number", 2)
+                            .set("price", Arbitraries.integers().greaterOrEqual(1).lessOrEqual(10).map(n -> n * 10000))
+                            .set("status", Values.just(SeatStatus.EMPTY))
+                            .sample()
+            );
+
+            int concurrentRequestCount = 5;
+            ExecutorService executorService = Executors.newFixedThreadPool(3);
+            CountDownLatch latch = new CountDownLatch(concurrentRequestCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            for (int i = 0; i < concurrentRequestCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        reservationFacade.reserve(schedule.getConcertScheduleId(), user.getUserId(),
+                                List.of(seat1.getSeatId(), seat2.getSeatId()));
+                        successCount.incrementAndGet();
+                    } catch (CustomException e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+            executorService.shutdown();
+
+            // then
+            assertThat(successCount.get()).isEqualTo(1);
+            assertThat(failCount.get()).isEqualTo(4);
+        }
+    }
+}

--- a/src/test/java/io/project/concertbooking/domain/point/PointServiceConcurrencyTest.java
+++ b/src/test/java/io/project/concertbooking/domain/point/PointServiceConcurrencyTest.java
@@ -1,0 +1,78 @@
+package io.project.concertbooking.domain.point;
+
+import com.navercorp.fixturemonkey.customizer.Values;
+import io.project.concertbooking.domain.user.User;
+import io.project.concertbooking.infrastructure.point.repository.PointJpaRepository;
+import io.project.concertbooking.infrastructure.user.repository.UserJpaRepository;
+import io.project.concertbooking.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[PointService - 동시성 테스트]")
+class PointServiceConcurrencyTest extends IntegrationTestSupport {
+
+    @Autowired
+    PointService pointService;
+
+    @Autowired
+    UserJpaRepository userJpaRepository;
+
+    @Autowired
+    PointJpaRepository pointJpaRepository;
+
+    @Nested
+    @DisplayName("[charge() - 포인트 충전 테스트]")
+    class ChargeTest {
+
+        @DisplayName("5개의 충전 요청이 동시에 오더라도 5개의 충전 금액이 모두 반영되어야 한다.")
+        @RepeatedTest(value = 5, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
+        void charge() throws Exception {
+            // given
+            User user = userJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(User.class)
+                            .sample()
+            );
+            pointJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Point.class)
+                            .set("user", Values.just(user))
+                            .set("amount", 0)
+                            .sample()
+            );
+
+            int concurrentRequestCount = 5;
+            ExecutorService executorService = Executors.newFixedThreadPool(3);
+            CountDownLatch latch = new CountDownLatch(concurrentRequestCount);
+
+            // when
+            for (int i = 0; i < concurrentRequestCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        pointService.chargeWithLock(user, 1000);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+            executorService.shutdown();
+
+            // then
+            Optional<Point> pointOpt = pointJpaRepository.findByUser(user);
+            assertThat(pointOpt.isPresent()).isTrue();
+
+            Point point = pointOpt.get();
+            assertThat(point.getAmount()).isEqualTo(5000);
+        }
+    }
+}


### PR DESCRIPTION
## 참고 자료
- [대기열 토큰 검증 인터셉터 채택 보고서](https://github.com/park0691/concert-booking/issues/32)
- [요청, 응답 필터 채택 보고서](https://github.com/park0691/concert-booking/issues/35)

## PR 설명
- 포인트 충전, 콘서트 좌석 예약 로직에 비관적 락 적용하여 동시성 이슈 해결

## 리뷰 포인트
1. 대기열 토큰 검증에 인터셉터를 사용했습니다. 필터, 인터셉터 중 인터셉터를 채택한 이유에 대해 위 링크에 작성했는데 논리에 문제는 없는지, 더 달면 좋은 부분은 없는지 확인 부탁드립니다.
2. 현재 락 걸린 List<Seat>를 ReservationFacade에서 받아서 다시 reservationService로 넘기고 있습니다. 렇게 짰던 의도는 Seat와 Reservation의 도메인이 달라서 Facade에서 받아서 넘기도록 처리했던 걸로 기억합니다. 락걸린 List<Seat> 받는 로직을 reservationService 안으로 넣고 직접 ConcertRepository를 호출해서 받아오는 것이 나을까요? 아니면 그대로 두어도 적절할까요? [ReservationFacade.java](https://github.com/park0691/concert-booking/blob/master/src/main/java/io/project/concertbooking/application/reservation/ReservationFacade.java) 28~29L