### PR TITLE
테스트 환경 DateTimeProvider 컴포넌트 추가

### DIFF
--- a/src/test/java/io/project/concertbooking/domain/reservation/ReservationServiceIntegrationTest.java
+++ b/src/test/java/io/project/concertbooking/domain/reservation/ReservationServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import io.project.concertbooking.domain.concert.enums.SeatStatus;
 import io.project.concertbooking.domain.reservation.enums.ReservationStatus;
 import io.project.concertbooking.infrastructure.concert.repository.SeatJpaRepository;
 import io.project.concertbooking.infrastructure.reservation.ReservationJpaRepository;
+import io.project.concertbooking.support.CustomDateTimeProvider;
 import io.project.concertbooking.support.IntegrationTestSupportWithNoAuditing;
 import net.jqwik.api.Arbitraries;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +32,9 @@ class ReservationServiceIntegrationTest extends IntegrationTestSupportWithNoAudi
 
     @Autowired
     ReservationJpaRepository reservationJpaRepository;
+
+    @Autowired
+    CustomDateTimeProvider customDateTimeProvider;
 
     @Nested
     @DisplayName("[expireReservation() - 예약 만료 처리 테스트]")
@@ -87,35 +91,38 @@ class ReservationServiceIntegrationTest extends IntegrationTestSupportWithNoAudi
             seatJpaRepository.saveAll(List.of(seat1, seat2, seat3, seat4, seat5, seat6, seat7));
 
             LocalDateTime now = LocalDateTime.now();
+            customDateTimeProvider.setUserDefinedTime(now.minusMinutes(4));
             Reservation reservation1 = fixtureMonkey.giveMeBuilder(Reservation.class)
                     .setNull("user")
                     .set("seat", Values.just(seat2))
                     .set("seatNumber", seat2.getNumber())
                     .set("status", ReservationStatus.RESERVED)
-                    .set("regDt", now.minusMinutes(4))
                     .sample();
+            reservationJpaRepository.save(reservation1);
+            customDateTimeProvider.setUserDefinedTime(now.minusMinutes(5));
             Reservation reservation2 = fixtureMonkey.giveMeBuilder(Reservation.class)
                     .setNull("user")
                     .set("seat", Values.just(seat4))
                     .set("seatNumber", seat4.getNumber())
                     .set("status", ReservationStatus.RESERVED)
-                    .set("regDt", now.minusMinutes(5))
                     .sample();
+            reservationJpaRepository.save(reservation2);
+            customDateTimeProvider.setUserDefinedTime(now.minusMinutes(6));
             Reservation reservation3 = fixtureMonkey.giveMeBuilder(Reservation.class)
                     .setNull("user")
                     .set("seat", Values.just(seat6))
                     .set("seatNumber", seat6.getNumber())
                     .set("status", ReservationStatus.RESERVED)
-                    .set("regDt", now.minusMinutes(6))
                     .sample();
+            reservationJpaRepository.save(reservation3);
+            customDateTimeProvider.setUserDefinedTime(now.minusMinutes(7));
             Reservation reservation4 = fixtureMonkey.giveMeBuilder(Reservation.class)
                     .setNull("user")
                     .set("seat", Values.just(seat7))
                     .set("seatNumber", seat7.getNumber())
                     .set("status", ReservationStatus.RESERVED)
-                    .set("regDt", now.minusMinutes(7))
                     .sample();
-            reservationJpaRepository.saveAll(List.of(reservation1, reservation2, reservation3, reservation4));
+            reservationJpaRepository.save(reservation4);
 
             // when
             seatService.expireReservation(now);

--- a/src/test/java/io/project/concertbooking/support/CustomDateTimeProvider.java
+++ b/src/test/java/io/project/concertbooking/support/CustomDateTimeProvider.java
@@ -1,0 +1,26 @@
+package io.project.concertbooking.support;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.Optional;
+
+@Profile("test-no-auditing")
+@Component
+public class CustomDateTimeProvider implements DateTimeProvider {
+
+    private LocalDateTime userDefinedTime;
+
+    public void setUserDefinedTime(LocalDateTime userDefinedTime) {
+        this.userDefinedTime = userDefinedTime;
+    }
+
+    @Override
+    public Optional<TemporalAccessor> getNow() {
+        Optional<TemporalAccessor> dateTimeOpt = Optional.ofNullable(userDefinedTime);
+        return dateTimeOpt.or(() -> Optional.of(LocalDateTime.now()));
+    }
+}

--- a/src/test/java/io/project/concertbooking/support/JpaAuditingConfig.java
+++ b/src/test/java/io/project/concertbooking/support/JpaAuditingConfig.java
@@ -1,0 +1,11 @@
+package io.project.concertbooking.support;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing(dateTimeProviderRef = "customDateTimeProvider")
+@Configuration
+@Profile("test-no-auditing")
+public class JpaAuditingConfig {
+}


### PR DESCRIPTION
### 변경 내용 요약
- 테스트 환경에서 JPA Auditing을 통해 현재 시각 데이터 입력시 테스트 실패하는 문제 발생
    - 데이터 영속 시점에 현재 시간 대신 테스트 환경에서 셋팅한 시간이 입력되도록 하는 DateTimeProvider 컴포넌트 추가