### PR TITLE
[STEP-12] Redisson 분산 락 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.43.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/io/project/concertbooking/application/aop/DistributedLockAspect.java
+++ b/src/main/java/io/project/concertbooking/application/aop/DistributedLockAspect.java
@@ -1,0 +1,59 @@
+package io.project.concertbooking.application.aop;
+
+import io.project.concertbooking.common.annotation.DistributedLock;
+import io.project.concertbooking.common.exception.CustomException;
+import io.project.concertbooking.common.exception.ErrorCode;
+import io.project.concertbooking.common.util.CustomSpELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Order(0)
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private static final String LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(io.project.concertbooking.common.annotation.DistributedLock)")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock lock = method.getAnnotation(DistributedLock.class);
+        String key = LOCK_PREFIX + CustomSpELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), lock.key());
+        log.info("DistributedLock started with key [{}]", key);
+
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean acquired = rLock.tryLock(lock.waitTime(), lock.leaseTime(), lock.timeUnit());
+            if (!acquired) {
+                throw new CustomException(ErrorCode.COMMON_BAD_REQUEST);
+            }
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            throw new CustomException(ErrorCode.COMMON_BAD_REQUEST);
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock Already UnLock: methodName [{}], key [{}]",
+                        method.getName(), key
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/io/project/concertbooking/application/aop/DistributedMultiLockAspect.java
+++ b/src/main/java/io/project/concertbooking/application/aop/DistributedMultiLockAspect.java
@@ -1,0 +1,69 @@
+package io.project.concertbooking.application.aop;
+
+import io.project.concertbooking.common.annotation.DistributedMultiLock;
+import io.project.concertbooking.common.exception.CustomException;
+import io.project.concertbooking.common.exception.ErrorCode;
+import io.project.concertbooking.common.util.CustomSpELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+@Slf4j
+@Aspect
+@Order(0)
+@Component
+@RequiredArgsConstructor
+public class DistributedMultiLockAspect {
+
+    private static final String LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(io.project.concertbooking.common.annotation.DistributedMultiLock)")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedMultiLock lock = method.getAnnotation(DistributedMultiLock.class);
+
+        String ids = String.valueOf(CustomSpELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), lock.keyIds()));
+        String[] keys = Arrays.stream(ids.split(","))
+                .map(s -> LOCK_PREFIX + lock.keyPrefix() + s)
+                .toArray(String[]::new);
+        RLock multiLock = redissonClient.getMultiLock(
+                Arrays.stream(keys)
+                        .map(redissonClient::getLock)
+                        .toArray(RLock[]::new)
+        );
+
+        try {
+            log.info("DistributedMultiLock is locking with keys {}", Arrays.toString(keys));
+            boolean acquired = multiLock.tryLock(lock.waitTime(), lock.leaseTime(), lock.timeUnit());
+            if (!acquired) {
+                throw new InterruptedException();
+            }
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            log.error("DistributedMultiLock failed to acquire lock with keys {}", Arrays.toString(keys));
+            throw new CustomException(ErrorCode.COMMON_REQUEST_CONFLICT);
+        } finally {
+            try {
+                log.info("DistributedMultiLock unlocking with keys {}", Arrays.toString(keys));
+                multiLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.error("DistributedMultiLock already unlocked: methodName {}, keys {}",
+                        method.getName(), Arrays.toString(keys)
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/io/project/concertbooking/application/payment/PaymentFacade.java
+++ b/src/main/java/io/project/concertbooking/application/payment/PaymentFacade.java
@@ -31,7 +31,7 @@ public class PaymentFacade {
         Reservation reservation = reservationService.findReservation(reservationId);
 
         // 포인트를 차감한다.
-        pointService.use(user, price);
+        pointService.useWithDistributedLock(user, price);
 
         // 결제 내역을 생성한다.
         Payment payment = paymentService.createPayment(user, reservation, price, PaymentMethod.POINT);

--- a/src/main/java/io/project/concertbooking/application/point/PointFacade.java
+++ b/src/main/java/io/project/concertbooking/application/point/PointFacade.java
@@ -21,7 +21,7 @@ public class PointFacade {
     @Transactional
     public PointResult chargePoint(Long userId, Integer point) {
         User user = userService.findById(userId);
-        return resultMapper.toPointResult(pointService.chargeWithLock(user, point));
+        return resultMapper.toPointResult(pointService.chargeWithDistributedLock(user, point));
     }
 
     public PointResult getPoint(Long userId) {

--- a/src/main/java/io/project/concertbooking/common/annotation/DistributedLock.java
+++ b/src/main/java/io/project/concertbooking/common/annotation/DistributedLock.java
@@ -1,0 +1,33 @@
+package io.project.concertbooking.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/io/project/concertbooking/common/annotation/DistributedMultiLock.java
+++ b/src/main/java/io/project/concertbooking/common/annotation/DistributedMultiLock.java
@@ -1,0 +1,38 @@
+package io.project.concertbooking.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedMultiLock {
+    /**
+     * 락의 Prefix
+     */
+    String keyPrefix() default "";
+
+    /**
+     * 점유할 자원의 ID들
+     */
+    String keyIds() default "";
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/io/project/concertbooking/common/config/RedissonConfig.java
+++ b/src/main/java/io/project/concertbooking/common/config/RedissonConfig.java
@@ -1,0 +1,28 @@
+package io.project.concertbooking.common.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/io/project/concertbooking/common/exception/ErrorCode.java
+++ b/src/main/java/io/project/concertbooking/common/exception/ErrorCode.java
@@ -9,6 +9,9 @@ import static org.springframework.http.HttpStatus.*;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    /* Common */
+    COMMON_BAD_REQUEST(BAD_REQUEST, "CN001", "잘못된 요청입니다."),
+
     /* User */
     USER_NOT_FOUND(NOT_FOUND, "US001", "해당 유저의 정보를 찾을 수 없습니다."),
 

--- a/src/main/java/io/project/concertbooking/common/exception/ErrorCode.java
+++ b/src/main/java/io/project/concertbooking/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ import static org.springframework.http.HttpStatus.*;
 public enum ErrorCode {
     /* Common */
     COMMON_BAD_REQUEST(BAD_REQUEST, "CN001", "잘못된 요청입니다."),
+    COMMON_REQUEST_CONFLICT(CONFLICT, "CN002", "리소스 충돌로 처리에 실패했습니다."),
 
     /* User */
     USER_NOT_FOUND(NOT_FOUND, "US001", "해당 유저의 정보를 찾을 수 없습니다."),

--- a/src/main/java/io/project/concertbooking/common/util/CustomSpELParser.java
+++ b/src/main/java/io/project/concertbooking/common/util/CustomSpELParser.java
@@ -1,0 +1,20 @@
+package io.project.concertbooking.common.util;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpELParser {
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String name) {
+        ExpressionParser parser = new SpelExpressionParser();
+        EvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(name).getValue(context);
+    }
+}

--- a/src/main/java/io/project/concertbooking/common/util/CustomSpELParser.java
+++ b/src/main/java/io/project/concertbooking/common/util/CustomSpELParser.java
@@ -1,20 +1,25 @@
 package io.project.concertbooking.common.util;
 
-import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
+import java.util.function.Function;
+
 public class CustomSpELParser {
 
-    public static Object getDynamicValue(String[] parameterNames, Object[] args, String name) {
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String name) throws NoSuchMethodException {
         ExpressionParser parser = new SpelExpressionParser();
-        EvaluationContext context = new StandardEvaluationContext();
-
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        context.registerFunction("convertToString", CustomSpELParser.class.getMethod("convertToString"));
         for (int i = 0; i < parameterNames.length; i++) {
             context.setVariable(parameterNames[i], args[i]);
         }
 
         return parser.parseExpression(name).getValue(context);
+    }
+
+    public static Function<Long, String> convertToString() {
+        return String::valueOf;
     }
 }

--- a/src/main/java/io/project/concertbooking/domain/concert/ConcertService.java
+++ b/src/main/java/io/project/concertbooking/domain/concert/ConcertService.java
@@ -46,6 +46,7 @@ public class ConcertService {
 
         return seats;
     }
+
     public List<Seat> findSeatsWithLock(List<Long> seatIds) {
         List<Seat> seats = concertRepository.findSeatsWithLock(seatIds);
 

--- a/src/main/java/io/project/concertbooking/domain/point/PointService.java
+++ b/src/main/java/io/project/concertbooking/domain/point/PointService.java
@@ -1,5 +1,6 @@
 package io.project.concertbooking.domain.point;
 
+import io.project.concertbooking.common.annotation.DistributedLock;
 import io.project.concertbooking.common.exception.CustomException;
 import io.project.concertbooking.common.exception.ErrorCode;
 import io.project.concertbooking.domain.point.enums.TransactionType;
@@ -57,7 +58,36 @@ public class PointService {
     }
 
     @Transactional
+    @DistributedLock(key = "'point:' + #user.userId")
+    public Point chargeWithDistributedLock(User user, Integer chargePoint) {
+        Optional<Point> pointOpt = pointRepository.findByUser(user);
+
+        Point point;
+
+        if (pointOpt.isPresent()) {
+            point = pointOpt.get();
+            point.charge(chargePoint);
+        } else {
+            point = Point.createPoint(user, chargePoint);
+        }
+        saveHistory(user, chargePoint, TransactionType.CHARGE);
+
+        return pointRepository.savePoint(point);
+    }
+
+    @Transactional
     public Point use(User user, Integer usePoint) {
+        Point point = pointRepository.findByUser(user)
+                .orElseGet(() -> pointRepository.savePoint(Point.createPoint(user, 0)));
+
+        point.use(usePoint);
+        saveHistory(user, usePoint, TransactionType.USE);
+        return point;
+    }
+
+    @Transactional
+    @DistributedLock(key = "'point:' + #user.userId")
+    public Point useWithDistributedLock(User user, Integer usePoint) {
         Point point = pointRepository.findByUser(user)
                 .orElseGet(() -> pointRepository.savePoint(Point.createPoint(user, 0)));
 

--- a/src/main/java/io/project/concertbooking/domain/reservation/ReservationService.java
+++ b/src/main/java/io/project/concertbooking/domain/reservation/ReservationService.java
@@ -1,11 +1,10 @@
 package io.project.concertbooking.domain.reservation;
 
-import io.project.concertbooking.common.constants.QueueConstants;
 import io.project.concertbooking.common.exception.CustomException;
 import io.project.concertbooking.common.exception.ErrorCode;
 import io.project.concertbooking.domain.concert.*;
-import io.project.concertbooking.domain.reservation.enums.ReservationStatus;
 import io.project.concertbooking.domain.concert.enums.SeatStatus;
+import io.project.concertbooking.domain.reservation.enums.ReservationStatus;
 import io.project.concertbooking.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+  data:
+    redis:
+      host:
+      port:
+      repositories:
+        enabled: false
 decorator:
   datasource:
     p6spy:
@@ -60,6 +66,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      repositories:
+        enabled: false
   devtools:
     restart:
       enabled: true
@@ -67,6 +79,9 @@ decorator:
   datasource:
     p6spy:
       enable-logging: true
+logging:
+  level:
+    org.springframework.transaction.interceptor: trace
 springdoc:
   packages-to-scan: io.project.concertbooking.interfaces.api.v1
   default-consumes-media-type: application/json;charset=UTF-8
@@ -85,7 +100,16 @@ spring:
     url: jdbc:tc:mysql:8.3.0:///concert?TC_INITSCRIPT=file:src/main/resources/schema.sql
     username: application
     password: application
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      repositories:
+        enabled: false
 decorator:
   datasource:
     p6spy:
       enable-logging: true
+logging:
+  level:
+    org.springframework.transaction.interceptor: trace

--- a/src/test/java/io/project/concertbooking/application/reservation/ReservationFacadeConcurrencyTest.java
+++ b/src/test/java/io/project/concertbooking/application/reservation/ReservationFacadeConcurrencyTest.java
@@ -54,9 +54,9 @@ public class ReservationFacadeConcurrencyTest extends IntegrationTestSupport {
     @DisplayName("[createReservation() - 콘서트 좌석 예약 테스트]")
     class CreateReservationTest {
 
-        @DisplayName("동시에 5개의 예약 요청이 들어오면, 하나만 성공하고 4개는 실패한다.")
-        @RepeatedTest(value = 5, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
-        void createReservation() throws Exception {
+        @DisplayName("동시에 5개의 동일한 좌석에 대한 예약 요청이 들어오면, 하나만 성공하고 4개는 실패한다.")
+        @RepeatedTest(value = 10, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
+        void createReservationWithSameRequest() throws Exception {
             // given
             User user = userJpaRepository.save(
                     fixtureMonkey.giveMeBuilder(User.class)
@@ -120,5 +120,103 @@ public class ReservationFacadeConcurrencyTest extends IntegrationTestSupport {
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(4);
         }
+
+        @DisplayName("동시에 동일한 좌석을 포함한 5개의 예약 요청이 동시에 들어오면, 하나만 성공하고 4개는 실패한다.")
+        @RepeatedTest(value = 10, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
+        void createReservationWithDiffRequest() throws Exception {
+            // given
+            User user = userJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(User.class)
+                            .sample()
+            );
+            LocalDateTime now = LocalDateTime.now();
+            Concert concert = concertJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Concert.class)
+                            .set("name", Arbitraries.strings().withCharRange('A', 'Z').ofLength(10).map(s -> s + " Concert"))
+                            .sample()
+            );
+            ConcertSchedule schedule = concertScheduleJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(ConcertSchedule.class)
+                            .set("concert", Values.just(concert))
+                            .set("scheduleDt", DateTimes.dateTimes().atTheEarliest(now.plusDays(7L))
+                                    .atTheLatest(now.plusDays(60L)))
+                            .sample()
+            );
+            Seat seat1 = seatJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Seat.class)
+                            .set("concertSchedule", Values.just(schedule))
+                            .set("number", 1)
+                            .set("price", Arbitraries.integers().greaterOrEqual(1).lessOrEqual(10).map(n -> n * 10000))
+                            .set("status", Values.just(SeatStatus.EMPTY))
+                            .sample()
+            );
+            Seat seat2 = seatJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Seat.class)
+                            .set("concertSchedule", Values.just(schedule))
+                            .set("number", 2)
+                            .set("price", Arbitraries.integers().greaterOrEqual(1).lessOrEqual(10).map(n -> n * 10000))
+                            .set("status", Values.just(SeatStatus.EMPTY))
+                            .sample()
+            );
+            Seat seat3 = seatJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Seat.class)
+                            .set("concertSchedule", Values.just(schedule))
+                            .set("number", 3)
+                            .set("price", Arbitraries.integers().greaterOrEqual(1).lessOrEqual(10).map(n -> n * 10000))
+                            .set("status", Values.just(SeatStatus.EMPTY))
+                            .sample()
+            );
+            Seat seat4 = seatJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Seat.class)
+                            .set("concertSchedule", Values.just(schedule))
+                            .set("number", 4)
+                            .set("price", Arbitraries.integers().greaterOrEqual(1).lessOrEqual(10).map(n -> n * 10000))
+                            .set("status", Values.just(SeatStatus.EMPTY))
+                            .sample()
+            );
+
+            int concurrentRequestCount = 5;
+            ExecutorService executorService = Executors.newFixedThreadPool(3);
+            CountDownLatch latch = new CountDownLatch(concurrentRequestCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            List<Long> seats1 = List.of(seat1.getSeatId(), seat4.getSeatId());
+            List<Long> seats2 = List.of(seat2.getSeatId(), seat4.getSeatId());
+            List<Long> seats3 = List.of(seat4.getSeatId(), seat3.getSeatId());
+            List<Long> seats4 = List.of(seat2.getSeatId(), seat4.getSeatId());
+            List<Long> seats5 = List.of(seat1.getSeatId(), seat4.getSeatId());
+
+            // when
+            List.of(seats1, seats2, seats3, seats4, seats5).forEach(seats -> {
+                executorService.submit(() -> {
+                    try {
+                        reservationFacade.reserve(schedule.getConcertScheduleId(), user.getUserId(), seats);
+                        successCount.incrementAndGet();
+                    } catch (CustomException e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            });
+
+            latch.await();
+            executorService.shutdown();
+
+            // then
+            assertThat(successCount.get()).isEqualTo(1);
+            assertThat(failCount.get()).isEqualTo(4);
+
+            List<Seat> reservedSeats = seatJpaRepository.findAllByStatus(SeatStatus.RESERVED);
+            assertThat(reservedSeats)
+                    .as("5개의 요청 중 1개만 성공했다면 예약된 좌석들이 반환되어야 한다.")
+                    .isNotEmpty();
+            assertThat(reservedSeats)
+                    .as("5개의 요청 중 1개만 성공했다면 예약 상태의 좌석은 2개이어야 한다.")
+                    .hasSize(2);
+        }
+
     }
 }

--- a/src/test/java/io/project/concertbooking/domain/point/PointServiceConcurrencyTest.java
+++ b/src/test/java/io/project/concertbooking/domain/point/PointServiceConcurrencyTest.java
@@ -1,6 +1,7 @@
 package io.project.concertbooking.domain.point;
 
 import com.navercorp.fixturemonkey.customizer.Values;
+import io.project.concertbooking.common.exception.CustomException;
 import io.project.concertbooking.domain.user.User;
 import io.project.concertbooking.infrastructure.point.repository.PointJpaRepository;
 import io.project.concertbooking.infrastructure.user.repository.UserJpaRepository;
@@ -8,7 +9,6 @@ import io.project.concertbooking.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
@@ -35,8 +35,8 @@ class PointServiceConcurrencyTest extends IntegrationTestSupport {
     @DisplayName("[charge() - 포인트 충전 테스트]")
     class ChargeTest {
 
-        @DisplayName("5개의 충전 요청이 동시에 오더라도 5개의 충전 금액이 모두 반영되어야 한다.")
-        @RepeatedTest(value = 5, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
+        @DisplayName("10번의 포인트 충전 요청이 동시에 오더라도 10번의 요청이 모두 반영되어야 한다")
+        @RepeatedTest(value = 10, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
         void charge() throws Exception {
             // given
             User user = userJpaRepository.save(
@@ -50,15 +50,21 @@ class PointServiceConcurrencyTest extends IntegrationTestSupport {
                             .sample()
             );
 
-            int concurrentRequestCount = 5;
+            int concurrentRequestCount = 10;
             ExecutorService executorService = Executors.newFixedThreadPool(3);
             CountDownLatch latch = new CountDownLatch(concurrentRequestCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
 
             // when
             for (int i = 0; i < concurrentRequestCount; i++) {
                 executorService.submit(() -> {
                     try {
-                        pointService.chargeWithLock(user, 1000);
+                        pointService.chargeWithDistributedLock(user, 1000);
+                        successCount.incrementAndGet();
+                    } catch (CustomException e) {
+                        failCount.incrementAndGet();
                     } finally {
                         latch.countDown();
                     }
@@ -68,11 +74,68 @@ class PointServiceConcurrencyTest extends IntegrationTestSupport {
             executorService.shutdown();
 
             // then
+            assertThat(successCount.get()).isEqualTo(10);
+            assertThat(failCount.get()).isEqualTo(0);
+
             Optional<Point> pointOpt = pointJpaRepository.findByUser(user);
             assertThat(pointOpt.isPresent()).isTrue();
 
             Point point = pointOpt.get();
-            assertThat(point.getAmount()).isEqualTo(5000);
+            assertThat(point.getAmount()).isEqualTo(10000);
+        }
+    }
+
+    @Nested
+    @DisplayName("[use() - 포인트 사용 테스트]")
+    class UseTest {
+
+        @DisplayName("10번의 포인트 사용 요청이 동시에 오더라도 10번의 요청이 모두 반영되어야 한다")
+        @RepeatedTest(value = 10, name = "{currentRepetition}/{totalRepetitions} - {displayName}")
+        void use() throws Exception {
+            // given
+            User user = userJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(User.class)
+                            .sample()
+            );
+            pointJpaRepository.save(
+                    fixtureMonkey.giveMeBuilder(Point.class)
+                            .set("user", Values.just(user))
+                            .set("amount", 20000)
+                            .sample()
+            );
+
+            int concurrentRequestCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(3);
+            CountDownLatch latch = new CountDownLatch(concurrentRequestCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            for (int i = 0; i < concurrentRequestCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        pointService.useWithDistributedLock(user, 1000);
+                        successCount.incrementAndGet();
+                    } catch (CustomException e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+            executorService.shutdown();
+
+            // then
+            assertThat(successCount.get()).isEqualTo(10);
+            assertThat(failCount.get()).isEqualTo(0);
+
+            Optional<Point> pointOpt = pointJpaRepository.findByUser(user);
+            assertThat(pointOpt.isPresent()).isTrue();
+
+            Point point = pointOpt.get();
+            assertThat(point.getAmount()).isEqualTo(10000);
         }
     }
 }


### PR DESCRIPTION
## 참고 자료
- 좌석 예약, Redisson MultiLock 적용
  - [MultiLock 추가 commit](https://github.com/park0691/concert-booking/commit/d823198a33a859efa4e2fb0e11e8027d4574f8ce)
  - [예약 로직에 Lock 적용 commit](https://github.com/park0691/concert-booking/commit/b651636214cd6719e08d7e118c55883c714cf9f9)
  - [동시성 통합 테스트 commit](https://github.com/park0691/concert-booking/commit/4cdf3cd3159c17c203abb4329c9700c4522a70c2)
- 포인트 충전, Redisson Pub/Sub Lock 적용
  - [Pub/Sub Lock 추가 commit](https://github.com/park0691/concert-booking/commit/50a74c58961649b7e00f89ee6c7b6b70fec73868)
  - [포인트 충전 로직에 Lock 적용 commit](https://github.com/park0691/concert-booking/commit/e139f2a00220068dc6fb3e2df6f46bb0a2a02d36)
  - [동시성 통합 테스트 commit](https://github.com/park0691/concert-booking/commit/a7cf4a0fd97e848b2d117a8b2f6669ccb8746343)

## PR 설명
- 작성하던 동시성 이슈 분석 문서(STEP-11)를 실수로 날려서 작성한 코드(STEP-12)만 제출합니다...ㅠㅠ
- 동시성 문제가 발생하는 좌석 예약, 포인트 충전 기능에 Redisson 분산 락을 적용했습니다.

## 리뷰 포인트
- AOP는 패키지 구조를 어떻게 가져가는게 베스트일지 궁금합니다.
  1. 저는 AOP가 비즈니스 로직 단위에 적용된다 판단이 되어 DistributedLockAspect, DistributedMultiLockAspect를 application/aop 패키지 안에 넣었습니다. 적절할까요? [DistributedLockAspect.java](https://github.com/park0691/concert-booking/commit/d823198a33a859efa4e2fb0e11e8027d4574f8ce#diff-05a97f404038056842b989c747a78f2f062a49f041a48761b07a48c5a6ace9cc)
  2.  PR에는 들어있지 않지만, 별도 브랜치에 Lettuce로 Spin Lock을 구현했습니다. 이 때, 락을 직접 구현하기 위해 RedisTemplate에 직접 접근하는 LockManager 또한 `application/aop` 패키지 안에 일단 같이 넣어놨는데요... 락 매니저 또한 도메인 계층에 별도로 넣고, RedisTemplate에 직접 접근하는 Repository는 infrastructure 안에 패키징하는게 좋을까요? LockManager가 있는 경우 어떻게 두는게 좋을까요..? [LockManager.java](https://github.com/park0691/concert-booking/commit/08bba90361a3fde37ab77f465f72a8d20b80a35d#diff-c80b868a50c095a6bdf7985cbd9bf6fcadf1d056c20b2134e47610a53c77b3f2)
- 락을 걸 때 leaseTime을 줘서 락을 쥐고 있을 시간을 지정하고 있습니다.
  1. 만약 leaseTime 동안에 비즈니스 로직의 처리가 다 되지 않는 경우 락이 풀려서 동시성 이슈가 발생할 수 있을 것 같은데, 이런 경우에는 보통 어떻게 처리하나요? 현업에서 별도의 추가 처리 로직이 있을지 궁금합니다.
  2. leaseTime을 주는 이유가 계속 락을 쥐고 있으면 데드락이 발생할 수도 있어서 주는 것 같다 생각되는데 leaseTime을 주는 이유가 궁금합니다.
- AOP에서 락 획득할 때 락 획득에 실패하거나, 인터럽트 예외가 발생하는 경우, 동시 요청 발생으로 리소스 충돌이 발생했다 판단하여 HttpStatusCode 409(Conflict)로 예외 응답을 전송하도록 했습니다. 이런 상황에 다음 예외 처리가 적합할지 궁금합니다. [DistributedMultiLockAspect.java](https://github.com/park0691/concert-booking/commit/d823198a33a859efa4e2fb0e11e8027d4574f8ce#diff-05a97f404038056842b989c747a78f2f062a49f041a48761b07a48c5a6ace9cc), [ErrorCode.java](https://github.com/park0691/concert-booking/commit/d823198a33a859efa4e2fb0e11e8027d4574f8ce#diff-9559b461bdbf1c4524103affc12fe91bbcf70e39adb0099fbd2693309287c8f4)